### PR TITLE
Update size of book_id

### DIFF
--- a/database/CREATETABLES.sql
+++ b/database/CREATETABLES.sql
@@ -35,7 +35,7 @@ CREATE TABLE preference
 
 CREATE TABLE user_book
 (
-    book_id VARCHAR(12) NOT NULL,
+    book_id VARCHAR(2048) NOT NULL,
     user_id UNIQUEIDENTIFIER default NEWID() NOT NULL,
     FOREIGN KEY (user_id) REFERENCES user_info(user_id)
 );


### PR DESCRIPTION
I've already dropped all books in the database's user_book table and made a new user_book table with this new size so uploading bigger book_ids should work even before this is merged. This still needs to be merged though just so we have it on record that the size of the book_id has changed. 

The book tests as they're currently written still assume 12 characters for a book_id, but since the book endpoint just stores whatever id you give it as long as it fits the size constraints, that doesn't really matter. 